### PR TITLE
Use Nix instead

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "python3"
-run = "python3 source/main.py"
+run = "python source/main.py"
+language = "nix"

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,5 @@
+{ pkgs }: {
+    deps = [
+        pkgs.python38
+    ];
+}


### PR DESCRIPTION
[Nix](https://docs.replit.com/programming-ide/getting-started-nix) is a better repl type because it allows you to specify exactly what you need. It also removes the built-in packages that may not be wanted. This also lets you use whatever package manager you want, and doesn't force Poetry on you.

- Custom Python version (You can test on 3.10!)
- Choose what packages you want + custom package manager
- Don't like Poetry? No problem
- Add other things, like Nodejs or Vim
